### PR TITLE
Fix for issue #9 - Don't parse visitors' messages as markdown

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,8 @@ app.post('/hook', function(req, res){
             sendTelegramMessage(chatId,
                 "*Welcome to Intergram* \n" +
                 "Your unique chat id is `" + chatId + "`\n" +
-                "Use it to link between the embedded chat and this telegram chat");
+                "Use it to link between the embedded chat and this telegram chat",
+                "Markdown");
         } else if (reply) {
             let replyText = reply.text || "";
             let userId = replyText.split(':')[0];
@@ -64,13 +65,13 @@ io.on('connection', function(client){
 
 });
 
-function sendTelegramMessage(chatId, text) {
+function sendTelegramMessage(chatId, text, parseMode) {
     request
         .post('https://api.telegram.org/bot' + process.env.TELEGRAM_TOKEN + '/sendMessage')
         .form({
             "chat_id": chatId,
             "text": text,
-            "parse_mode": "Markdown"
+            "parse_mode": parseMode
         });
 }
 


### PR DESCRIPTION
Visitor messages have unexpected content and shouldn't be parsed as markdown, only custom messages like /start should use markdown.